### PR TITLE
Add Ruby 2.5 to AppVeyor build matrix

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,6 +5,7 @@ environment:
   matrix:
     - RUBY_VERSION: 24
     - RUBY_VERSION: 24-x64
+    - RUBY_VERSION: 25-x64
 
 cache:
   - vendor/bundle


### PR DESCRIPTION
The new Ruby version should be available now, see
[#1999](https://github.com/appveyor/ci/issues/1999).