### PR TITLE
travis: Remove `install` section in favor of the default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,9 @@ rvm:
   - '2.5'
   - '2.6'
 
+before_install:
+  - gem update --system
+  - gem --version
+
 script:
   - bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: xenial
+
 conditions: v1
 
 if: branch = master OR tag IS present

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,5 @@ rvm:
   - '2.5'
   - '2.6'
 
-install:
-  - bundle install --path vendor/bundle
-
 script:
   - bundle exec rake


### PR DESCRIPTION
The default install step is `bundle install --jobs=3 --retry=3`, installing gems into `vendor/bundle`.