### PR TITLE
travis: Add Ruby 2.7 to build matrix

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,6 @@
 
+image: Visual Studio 2019
+
 version: "{build}"
 
 environment:
@@ -6,7 +8,8 @@ environment:
     - RUBY_VERSION: 24
     - RUBY_VERSION: 24-x64
     - RUBY_VERSION: 25-x64
-    - RUBY_VERSION: 26-x64   
+    - RUBY_VERSION: 26-x64
+    - RUBY_VERSION: 27-x64
 
 cache:
   - vendor/bundle

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ rvm:
   - '2.4'
   - '2.5'
   - '2.6'
+  - '2.7'
 
 before_install:
   - gem --version


### PR DESCRIPTION
Ruby 2.7.0 has been relased on 25th Dec 2019.